### PR TITLE
[WIP] Update steps to become a service provider

### DIFF
--- a/docs/service-provider-setup.md
+++ b/docs/service-provider-setup.md
@@ -448,19 +448,19 @@ kubectl create secret generic laconic-registry --from-file=.dockerconfigjson=con
 laconic-so deployment --dir container-registry start
 ```
 
-6. Check the logs.
+8. Check the logs.
 
 ```
 laconic-so deployment --dir container-registry logs
 ```
 
-7. Check status and await succesful deployment:
+9. Check status and await succesful deployment:
 
 ```
 laconic-so deployment --dir container-registry status
 ```
 
-8. Confirm deployment by logging in:
+10. Confirm deployment by logging in:
 
 ```
 docker login container-registry.pwa.laconic.com --username so-reg-user --password pXDwO5zLU7M88x3aA
@@ -572,54 +572,54 @@ Modify the endpoints, user key, and bond ID according to your configuration.
 
 6. Publish a `WebappDeployer` record for the deployer backend by following the steps below:
 
-  - Setup GPG keys by following [these steps to create and export a key](https://git.vdb.to/cerc-io/webapp-deployment-status-api#keys)
+* Setup GPG keys by following [these steps to create and export a key](https://git.vdb.to/cerc-io/webapp-deployment-status-api#keys)
 
-  - Publish the webapp deployer record using the `publish-deployer-to-registry` command
+* Publish the webapp deployer record using the `publish-deployer-to-registry` command
 
-    ```
-    laconic-so publish-deployer-to-registry \
-    --laconic-config /home/root/webapp-deployer/data/config/laconic.yml \
-    --api-url https://webapp-deployer-api.my.domain.com
-    --public-key-file webapp-deployer-api.my.domain.com.pgp.pub \
-    --lrn lrn://laconic/deployers/webapp-deployer-api.my.domain.com  \
-    --min-required-payment 0
-    ```
+```
+laconic-so publish-deployer-to-registry \
+--laconic-config /home/root/webapp-deployer/data/config/laconic.yml \
+--api-url https://webapp-deployer-api.my.domain.com
+--public-key-file webapp-deployer-api.my.domain.com.pgp.pub \
+--lrn lrn://laconic/deployers/webapp-deployer-api.my.domain.com  \
+--min-required-payment 0
+  ```
 
-    Replace `my.domain.com` with the domain you have setup
+Replace `my.domain.com` with the domain you have setup
 
 7. Modify the contents of `webapp-deployer/config.env`:
 
-  ```
-  DEPLOYMENT_DNS_SUFFIX="pwa.laconic.com"
+```
+DEPLOYMENT_DNS_SUFFIX="pwa.laconic.com"
 
-  # this should match the name authority reserved above
-  DEPLOYMENT_RECORD_NAMESPACE="my-org-name"
+# this should match the name authority reserved above
+DEPLOYMENT_RECORD_NAMESPACE="my-org-name"
 
-  # url of the deployed docker image registry
-  IMAGE_REGISTRY="container-registry.pwa.laconic.com"
+# url of the deployed docker image registry
+IMAGE_REGISTRY="container-registry.pwa.laconic.com"
 
-  # credentials from the htpasswd section above
-  IMAGE_REGISTRY_USER="so-reg-user"
-  IMAGE_REGISTRY_CREDS="pXDwO5zLU7M88x3aA"
+# credentials from the htpasswd section above
+IMAGE_REGISTRY_USER="so-reg-user"
+IMAGE_REGISTRY_CREDS="pXDwO5zLU7M88x3aA"
 
-  # configs
-  CLEAN_DEPLOYMENTS=false
-  CLEAN_LOGS=false
-  CLEAN_CONTAINERS=false
-  SYSTEM_PRUNE=false
-  WEBAPP_IMAGE_PRUNE=true
-  CHECK_INTERVAL=5
-  FQDN_POLICY="allow"
+# configs
+CLEAN_DEPLOYMENTS=false
+CLEAN_LOGS=false
+CLEAN_CONTAINERS=false
+SYSTEM_PRUNE=false
+WEBAPP_IMAGE_PRUNE=true
+CHECK_INTERVAL=5
+FQDN_POLICY="allow"
 
-  # lrn of the webapp deployer
-  LRN="lrn://laconic/deployers/webapp-deployer-api.laconic.com"
+# lrn of the webapp deployer
+LRN="lrn://laconic/deployers/webapp-deployer-api.laconic.com"
 
-  # Path to the GPG key file inside the webapp-deployer container
-  export OPENPGP_PRIVATE_KEY_FILE="webapp-deployer-api.laconic.com.pgp.key"
+# Path to the GPG key file inside the webapp-deployer container
+export OPENPGP_PRIVATE_KEY_FILE="webapp-deployer-api.laconic.com.pgp.key"
 
-  # Passphrase used when creating the GPG key
-  export OPENPGP_PASSPHRASE="SECRET"
-  ```
+# Passphrase used when creating the GPG key
+export OPENPGP_PASSPHRASE="SECRET"
+```
 
 8. Push the image to the container registry.
 ```
@@ -635,15 +635,15 @@ Publishing records to the Laconic Registry will trigger deployments in your back
 
 10. Copy the GPG key file to the webapp-deployer container:
 
-  ```bash
-  # Get the webapp-deployer pod id
-  kubectl get pods --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}'
-  # laconic-ac473c31db9ac9fd-deployment-674bf7bf9f-529bs
+```bash
+# Get the webapp-deployer pod id
+kubectl get pods --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}'
+# laconic-ac473c31db9ac9fd-deployment-674bf7bf9f-529bs
 
-  # Copy the GPG key file to the pod
-  kubectl cp gpg-keys/webapp-deployer-api.laconic.com.pgp.key laconic-ac473c31db9ac9fd-deployment-674bf7bf9f-529bs:/app
-  ```
-  - Replace `laconic` with your configured domain
+# Copy the GPG key file to the pod
+kubectl cp gpg-keys/webapp-deployer-api.laconic.com.pgp.key laconic-ac473c31db9ac9fd-deployment-674bf7bf9f-529bs:/app
+```
+* Replace `laconic.com` with your configured domain
 
 ## Deploy frontend
 
@@ -680,7 +680,28 @@ laconic-so deployment --dir webapp-ui start
 2. Review this file: `.github/workflows/publish.yaml`.
 3. Update `scripts/publish-app-record.sh` with relevant endpoints (or set the environment variables).
 4. Update `package.json` fields: `"name": "@my-org-name/app-name` and `"repository": "url_to_your_fork_must_be_public"`
-5. Add the envs referenced in `.github/workflows/publish.yaml`, i.e., for `privKey` and `bondId` as Secrets in GitHub Actions.
+5. Add the following envs referenced in `.github/workflows/publish.yaml` as Secrets in GitHub Actions:
+
+  ```bash
+  # Private key acquired while setting up fixturenet-laconicd-deployment
+  CICD_LACONIC_USER_KEY
+
+  # ID of the bond that you created
+  CICD_LACONIC_BOND_ID
+
+  # RPC endpoint for the laconicd chain, eg: https://lcn-daemon.laconic.com:26657
+  CICD_LACONIC_REST_ENDPOINT
+
+  # GQL endpoint for the laconicd chain, eg: https://lcn-daemon.laconic.com:9473/api
+  CICD_LACONIC_GQL_ENDPOINT
+
+  # The sudomain name where webapp deployment is requested, eg: loro-testnet-app
+  CICD_LACONIC_DNS
+
+  # LRN of the webapp-deployer, eg: lrn://laconic/deployers/webapp-deployer-api.laconic.com
+  CICD_LACONIC_DEPLOYER_LRN
+  ```
+
 Now, anytime a release is created, a new set of records will be published to the Laconic Registry, and eventually picked up by the `deployer`, which will target the k8s cluster that was setup.
 
 **Note:** to override the default webapp build process, put a file named `build-webapp.sh` in the root of the repo.

--- a/docs/service-provider-setup.md
+++ b/docs/service-provider-setup.md
@@ -19,7 +19,7 @@ Using DigitalOcean's droplets as reference, these are the minimum suggested spec
 ## Configure DNS
 
 Point your nameservers to DigitalOcean and create the following A and CNAME records from the DigitalOcean Dashboard.
- 
+
 Like this:
 
 |  Type  |            Hostname                  |            Value                     |
@@ -63,7 +63,7 @@ apt update && apt upgrade -y
 3. Install additional packages.
 
 ```
-apt install -y doas zsh tmux git jq acl curl wget netcat-traditional fping rsync htop iotop iftop tar less firewalld sshguard wireguard iproute2 iperf3 zfsutils-linux net-tools ca-certificates gnupg sshpass
+apt install -y doas zsh tmux git jq acl curl wget netcat-traditional fping rsync htop iotop iftop tar less firewalld sshguard wireguard iproute2 iperf3 zfsutils-linux net-tools ca-certificates gnupg sshpass apache2-utils
 ```
 
 Select "Yes" when prompted for iperf3.
@@ -233,8 +233,8 @@ metadata:
   namespace: cert-manager
 ```
 
-19.  Remove the `./group_vars/lcn_cad/k8s-vault.yml` file. 
-  
+19.  Remove the `./group_vars/lcn_cad/k8s-vault.yml` file.
+
 ```
 rm ./group_vars/lcn_cad/k8s-vault.yml
 ```
@@ -333,7 +333,7 @@ ansible-vault encrypt path/to/file.yaml
 
 and the result overwrites the original file with the encrypted version.
 
-To decrypt that file, run: 
+To decrypt that file, run:
 
 ```
 echo 'content-of-the-file' | ansible-vault decrypt
@@ -502,7 +502,10 @@ Follow [these steps](https://github.com/hyphacoop/loro-testnet/blob/main/docs/in
 
 This service listens for `ApplicationDeploymentRequest`'s in the Laconic Registry and automatically deploys an application to the k8s cluster.
 
-1. Initialize a spec file for the deployer backend.
+1. Publish a `WebappDeployer` record for the deployer backend by following [these steps](https://git.vdb.to/cerc-io/webapp-deployment-status-api#configuration)
+
+
+2. Initialize a spec file for the deployer backend.
 
 ```
 laconic-so --stack webapp-deployer-backend setup-repositories
@@ -510,7 +513,7 @@ laconic-so --stack webapp-deployer-backend build-containers
 laconic-so --stack webapp-deployer-backend deploy init --output webapp-deployer.spec
 ```
 
-2. Modify the contents of `webapp-deployer.spec`:
+3. Modify the contents of `webapp-deployer.spec`:
 
 ```
 stack: webapp-deployer-backend
@@ -520,14 +523,14 @@ image-registry: container-registry.pwa.laconic.com/laconic-registry
 network:
   ports:
     server:
-     - '9555'
+      - '9555'
   http-proxy:
     - host-name: webapp-deployer-api.pwa.laconic.com
       routes:
         - path: '/'
           proxy-to: server:9555
 volumes:
-  srv: 
+  srv:
 configmaps:
   config: ./data/config
 annotations:
@@ -550,11 +553,11 @@ resources:
       storage: 200G
 ```
 
-3. Create the deployment directory from the spec file.
+4. Create the deployment directory from the spec file.
 ```
 laconic-so --stack webapp-deployer-backend deploy create --deployment-dir webapp-deployer --spec-file webapp-deployer.spec
 ```
-4. Modify the contents of `webapp-deployer/config.env`:
+5. Modify the contents of `webapp-deployer/config.env`:
 
 ```
 DEPLOYMENT_DNS_SUFFIX="pwa.laconic.com"
@@ -579,8 +582,8 @@ CHECK_INTERVAL=5
 FQDN_POLICY="allow"
 ```
 
-5. Copy `~/.kube/config-default.yaml` from the k8s cluster creation step to `webapp-deployer/data/config/kube.yml`
-6. Create `webapp-deployer/data/config/laconic.yml`, it should look like this:
+6. Copy `~/.kube/config-default.yaml` from the k8s cluster creation step to `webapp-deployer/data/config/kube.yml`
+7. Create `webapp-deployer/data/config/laconic.yml`, it should look like this:
 ```
 services:
   registry:
@@ -589,17 +592,17 @@ services:
     userKey: e64ae9d07b21c62081b3d6d48e78bf44275ffe0575f788ea7b36f71ea559724b
     bondId: ad9c977f4a641c2cf26ce37dcc9d9eb95325e9f317aee6c9f33388cdd8f2abb8
     chainId: lorotestnet-1
-    gas: 995000
+    gas: 200000
     fees: 500000alnt
 ```
 Modify the endpoints, user key, and bond ID according to your configuration.
 
-7. Push the image to the container registry.
+8. Push the image to the container registry.
 ```
 laconic-so deployment --dir webapp-deployer push-images
 ```
 
-8. Start the deployer.
+9. Start the deployer.
 ```
 laconic-so deployment --dir webapp-deployer start
 ```
@@ -642,7 +645,7 @@ laconic-so deployment --dir webapp-ui start
 3. Update `scripts/publish-app-record.sh` with relevant endpoints (or set the environment variables).
 4. Update `package.json` fields: `"name": "@my-org-name/app-name` and `"repository": "url_to_your_fork_must_be_public"`
 5. Add the envs referenced in `.github/workflows/publish.yaml`, i.e., for `privKey` and `bondId` as Secrets in GitHub Actions.
-
+6. Follow [these steps](https://git.vdb.to/cerc-io/webapp-deployment-status-api#request-deployment) to request a webapp deployment
 Now, anytime a release is created, a new set of records will be published to the Laconic Registry, and eventually picked up by the `deployer`, which will target the k8s cluster that was setup.
 
 **Note:** to override the default webapp build process, put a file named `build-webapp.sh` in the root of the repo.
@@ -656,4 +659,3 @@ We now have:
 - https://webapp-deployer-api.pwa.laconic.com listens for ApplicationDeploymentRequest and runs `laconic-so deploy-webapp-from-registry` behind the scenes
 - https://webapp-deployer-ui.pwa.laconic.com displays status and logs for webapps deployed via the Laconic Registry
 - https://app-name-45wjhbhef.pwa.laconic.com is the webapp deployed above
-


### PR DESCRIPTION
Part of [Service Provider setup](https://www.notion.so/Service-provider-setup-a09e2207e1f34f3a847f7ce9713b7ac5) 
- Add step to publish webapp-deployer record
- Add required variables for webapp-deployer config
- Add `apache2-utils` package for using `htpasswd`
- Add details to setup secrets for webapp requester CI
  - Requires https://github.com/LaconicNetwork/loro-testnet-example-pwa/pull/4